### PR TITLE
lfs-perl 5.38 -> 5.40

### DIFF
--- a/general.ent
+++ b/general.ent
@@ -112,7 +112,7 @@
 <!-- These entities are used to identify versions of LFS
      packages referenced throughout the BLFS book. -->
 
-<!ENTITY lfs-perl-version             "5.38"> <!-- used in git -->
+<!ENTITY lfs-perl-version             "5.40"> <!-- used in git -->
 
 <!-- End LFS versions -->
 


### PR DESCRIPTION
Hi Zeckma, I noticed a version mismatch on the GLFS Git page. The BLFS Git page has Perl at version 5.40.

In my testing, Git built successfully with Perl 5.40.