### PR TITLE
llvm: 1.19.0 -> 1.19.3; spirv-llvm-translator: 1.19.0 -> 1.19.1

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -141,7 +141,7 @@
 <!ENTITY amdgpu-pro-libamdenc-version "1.0">
 <!ENTITY nvidia-version               "560.35.03">
 <!ENTITY llvm-maj-version             "19">
-<!ENTITY llvm-point-version           "0">
+<!ENTITY llvm-point-version           "3">
 <!ENTITY llvm-version                 "&llvm-maj-version;.1.&llvm-point-version;">
 <!ENTITY rust-version                 "1.82.0">
 <!ENTITY cbindgen-version             "0.27.0">
@@ -151,7 +151,7 @@
 <!ENTITY libva-version                "2.22.0">
 <!ENTITY libvdpau-version             "1.5">
 <!ENTITY libvdpau-va-gl-version       "0.4.2">
-<!ENTITY spirv-llvm-translator-version "&llvm-version;">
+<!ENTITY spirv-llvm-translator-version "&llvm-maj-version;.1.1;">
 <!ENTITY libclc-version               "&llvm-version;">
 <!ENTITY ply-version                  "3.11">
 <!ENTITY cython-version               "3.0.11">


### PR DESCRIPTION
Hello,

I updated llvm to 1.19.3 (as have gentoo and crux). The latest version of spirv-llvm-translator is behind, though, which I've accounted for. llvm and spirv-llvm-translator both built without issue.