### PR TITLE
cmake: 3.30.5 -> 3.31.0

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -109,8 +109,8 @@
 <!ENTITY libXpresent-version          "1.0.1">
 <!-- END X7LIB -->
 <!ENTITY libxcvt-version              "0.1.2">
-<!ENTITY cmake-major-version          "3.30">
-<!ENTITY cmake-minor-version          "5">
+<!ENTITY cmake-major-version          "3.31">
+<!ENTITY cmake-minor-version          "0">
 <!ENTITY cmake-version                "&cmake-major-version;.&cmake-minor-version;">
 <!ENTITY libunwind-version            "1.8.1">
 <!ENTITY nettle-version               "3.10">


### PR DESCRIPTION
Hello,

I updated CMake. It built without issue. Vulkan-*-1.3.301 and libclc-19.1.3 also built without issue using CMake-3.31.0. (I felt like testing it.)