### PR TITLE
Wget: 1.24.5 -> 1.25.0

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -17,7 +17,7 @@
 <!ENTITY libidn2-version              "2.3.7">
 <!ENTITY libpsl-version               "0.21.5">
 <!ENTITY curl-version                 "8.11.0">
-<!ENTITY wget-version                 "1.24.5">
+<!ENTITY wget-version                 "1.25.0">
 <!ENTITY git-version                  "2.47.0">
 <!-- Security -->
 <!ENTITY dbus-version                 "1.14.10">   <!-- Even minors only -->


### PR DESCRIPTION
Hello, I updated wget to its latest version. It built without issue.

The test results (which aren't particularly meaningful since I don't have the testing dependencies) are identical to 1.24.5. Wget 1.25.0 still works great for downloading tarballs and such.