### PR TITLE
libgpg-error: 1.50 -> 1.51

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -246,7 +246,7 @@
 <!-- CHAPTER IV - STEAM -->
 
 <!ENTITY xdg-user-dirs-version        "0.18">
-<!ENTITY libgpg-error-version         "1.50">
+<!ENTITY libgpg-error-version         "1.51">
 <!ENTITY steam-version                "1.0.0.82">
 
 


### PR DESCRIPTION
Hello, I updated libgpg-error to its latest version. Libgpg-error 1.51 built without issue and passed all 13 tests.