### PR TITLE
libxml2: 2.13.4 -> 2.13.5

### DIFF
--- a/packages.ent
+++ b/packages.ent
@@ -34,7 +34,7 @@
 <!ENTITY icu-minor                    "1">
 <!ENTITY icu-patch                    "0">
 <!ENTITY icu-version                  "&icu-major;.&icu-minor;">
-<!ENTITY libxml2-version              "2.13.4">
+<!ENTITY libxml2-version              "2.13.5">
 <!ENTITY shared-mime-info-version     "2.4">
 <!ENTITY desktop-file-utils-version   "0.28">
 <!ENTITY polkit-version               "125">


### PR DESCRIPTION
Hello, I updated libxml2 to its latest version. Built without issue and *LFS successfully compiled with the new libxml2-2.13.5.