### PR TITLE
Steam: fixed doc versioning inconsistency

### DIFF
--- a/steam/steam/steam.xml
+++ b/steam/steam/steam.xml
@@ -68,7 +68,7 @@
     </para>
 
   <screen role="root"><userinput>make install   &amp;&amp;
-mv -vf /usr/share/doc/steam{,-&steam-version;}</userinput></screen>
+ln -sfv steam /usr/share/doc/steam-&steam-version;</userinput></screen>
 
   </sect2>
 

--- a/steam/steam/steam.xml
+++ b/steam/steam/steam.xml
@@ -67,7 +67,8 @@
       </systemitem> user:
     </para>
 
-<screen role="root"><userinput>make install</userinput></screen>
+  <screen role="root"><userinput>make install   &amp;&amp;
+mv -vf /usr/share/doc/steam{,-&steam-version;}</userinput></screen>
 
   </sect2>
 


### PR DESCRIPTION
Hello,

This one's kinda a nitpick, but it's something that *LFS makes a point of doing. When installing packages, often the Makefiles install unversioned directories into /usr/share/doc. *LFS works around this, labelling them by version through seds or mv. This commit adds an extra line to Steam's install instructions to be consistent with the rest of *LFS.

This is not the only such package; this is just one I noticed and wanted to fix.