### PR TITLE
Improved switch-theme.sh

### DIFF
--- a/switch-theme.sh
+++ b/switch-theme.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
-if [ "$1" == "light" ]; then
-  ln -svf light.lfs.css stylesheets/lfs-xsl/lfs.css
-elif [ "$1" == "dark" ]; then
-  ln -svf dark.lfs.css stylesheets/lfs-xsl/lfs.css
+
+available_themes=$(ls stylesheets/lfs-xsl/*.lfs.css | sed 's|stylesheets/lfs-xsl/\(.*\)\.lfs.css|\1|')
+
+if echo "$available_themes" | grep -q -w "$1"; then
+  ln -sfv "$1.lfs.css" stylesheets/lfs-xsl/lfs.css
 else
-  echo '"'"$1"'" is not "light" or "dark"'
+  echo 'Invalid theme!' >&2
+  echo
+  echo 'Available themes:'
+  echo "$available_themes"
+  exit 1
 fi


### PR DESCRIPTION
Hello,

I use custom themes for GLFS, and though I probably am alone in doing so, I think making switch-theme.sh more extensible and user-friendly is a good idea. So I've gone ahead and done that.

The script now checks the available themes (files in stylesheets/lfs-xsl/*.lfs.css), and compares them to $1. If a matching theme exists, the lfs.css symlink is made.

Here's some example output:
```bash
 [ /code/glfs ]$ ./switch-theme.sh invalid
Invalid theme!

Available themes:
dark
light
nightdrive
pinkmecha
whitepink
# The extra themes here are my custom ones
```

And for a valid theme:
```bash
 [ /code/glfs ]$ ./switch-theme.sh pinkmecha
'stylesheets/lfs-xsl/lfs.css' -> 'pinkmecha.lfs.css'
```