### PR TITLE
Avoid calling switch-theme.sh twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ $(BASEDIR)/index.html: $(RENDERTMP)/$(GLFSHTML) version
 		mkdir -p $(BASEDIR)/patches;          \
    fi;
 	$(Q)cp patches/*.patch $(BASEDIR)/patches
-	$(Q)./switch-theme.sh dark
 
 	@echo "Running Tidy and obfuscate.sh on chunked XHTML..."
 	$(Q)for filename in `find $(BASEDIR) -name "*.html"`; do       \


### PR DESCRIPTION
Hi,

Recreating the default symlink to the dark theme is pointless, since it will always be overwritten by whatever the theme is set to in the Makefile anyway.

I've been using GLFS with only one switch-theme.sh call for some time now, and have not run into any issues.