### PR TITLE
Polkit: Avoid group/user-related command failures on update

### DIFF
--- a/shareddeps/security/polkit.xml
+++ b/shareddeps/security/polkit.xml
@@ -110,8 +110,9 @@
       <systemitem class="username">root</systemitem> user:
     </para>
 
-<screen role="root"><userinput>groupadd -fg 27 polkitd &amp;&amp;
-useradd -c "PolicyKit Daemon Owner" -d /etc/polkit-1 -u 27 \
+<screen role="root"><userinput>getent group polkitd || groupadd -fg 27 polkitd &amp;&amp;
+id polkitd || useradd -c "PolicyKit Daemon Owner" \
+        -d /etc/polkit-1 -u 27 \
         -g polkitd -s /bin/false polkitd</userinput></screen>
 
     <para>


### PR DESCRIPTION
Hey Zeckma,

Currently, the commands to install polkit fail if the group or user exist. To address this, I've added a check for each to prevent non-zero exit statuses in the case they exist. I'm not sure if this sort of error handling is a goal of {B,G}LFS, but I personally find this useful as I use `set -e` in my build scripts.

I wasn't sure if explanations needed to be issued for the checks. If they do, let me know and I'll add them.