### PR TITLE
libaom: Fix building the 32-bit version of libaom.

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>February 3rd, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[renodr] - libaom: fix building the 32-bit libraries. Fixes
+          <ulink url="&glfs-issues;/89">#89</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[zeckma] - linux: 6.12.8 -&gt; 6.13.1.</para>
         </listitem>
         <listitem>

--- a/wine/deps/misc/libaom.xml
+++ b/wine/deps/misc/libaom.xml
@@ -102,11 +102,13 @@ rm -v /usr/lib/libaom.a</userinput></screen>
       commands:
     </para>
 
-<screen><userinput>cmake -D CMAKE_INSTALL_PREFIX=/usr  \
-      -D CMAKE_INSTALL_LIBDIR=lib32 \
-      -D CMAKE_BUILD_TYPE=Release   \
-      -D BUILD_SHARED_LIBS=1        \
-      -D ENABLE_DOCS=no             \
+<screen><userinput>CC="gcc -m32" CXX="g++ -m32"         \
+PKG_CONFIG_PATH=/usr/lib32/pkgconfig \
+cmake -D CMAKE_INSTALL_PREFIX=/usr   \
+      -D CMAKE_INSTALL_LIBDIR=lib32  \
+      -D CMAKE_BUILD_TYPE=Release    \
+      -D BUILD_SHARED_LIBS=1         \
+      -D ENABLE_DOCS=no              \
       -G Ninja .. &amp;&amp;
 
 ninja</userinput></screen>


### PR DESCRIPTION
We were missing the CC, CXX, and PKG_CONFIG_PATH variables, so CMake was generating 64-bit copies of the libraries and then we were installing them into /usr/lib32.

This fixes the issue by setting the CC, CXX, and PKG_CONFIG_PATH variables prior to running CMake.

Fixes #89 