### PR TITLE
Fix a broken link for Xorg Fonts

### DIFF
--- a/shareddeps/dps/x/x7font.xml
+++ b/shareddeps/dps/x/x7font.xml
@@ -25,7 +25,7 @@
       fonts and supporting packages for <application>Xorg</application>
       applications. Many people will want to install other TTF or OTF fonts in
       addition to, or instead of, these. Some are listed at <ulink
-      url="&blfs-svn;/x/TTF-and-OTF-fonts">TTF-and-OTF-fonts</ulink>.
+      url="&blfs-svn;/x/TTF-and-OTF-fonts.html">TTF-and-OTF-fonts</ulink>.
     </para>
 
     <itemizedlist spacing="compact">


### PR DESCRIPTION
The link to https://linuxfromscratch.org/blfs/view/svn/x/TTF-and-OTF-fonts.html on the Xorg Fonts page was missing the trailing '.html'.

I believe a similar issue existed before, but I can't find it. I ran a quick grep after noticing this to see if I could find any similar dead links, but only found this one:

```
$ rg 'url="\&blfs' | rg -v html
shareddeps/dps/x/x7font.xml:      url="&blfs-svn;/x/TTF-and-OTF-fonts">TTF-and-OTF-fonts</ulink>.`
```

