### PR TITLE
NVIDIA: Refactor `nvidia_symlink()`

### DIFF
--- a/shareddeps/drivers/nvidia.xml
+++ b/shareddeps/drivers/nvidia.xml
@@ -315,14 +315,18 @@ cp -v firmware/*.bin /usr/lib/firmware/nvidia/&nvidia-version;</userinput></scre
 # &copyholder;, &copyrightdate;.
 
 nvidia_symlink() {
-  soname=$(readelf -d $1.so.*.*.* | \
-    grep '(SONAME)' | sed -n 's/.*\[\(.*\)\]/\1/p')
-  if test -n $soname; then
-    test -e $(dirname $1)/$soname || \
-      ln -svf $1.so.*.*.* $(dirname $1)/$soname
-    test -e $1.so || \
-      ln -svf $soname $1.so
+  pushd $(dirname $1) &gt; /dev/null
+
+  origin=$(basename $1)
+  soname=$(objdump -p $origin.so.*.*.* |
+    grep 'SONAME' | awk '{print $2}')
+
+  if [ -n $soname ]; then
+    [ -e $soname ]    || ln -sv $origin.so.*.*.* $soname
+    [ -e $origin.so ] || ln -sv $soname $origin.so
   fi
+
+  popd &gt; /dev/null
 }
 </literal>
 EOF</userinput></screen>


### PR DESCRIPTION
The `nvidia_symlink()` currently in GLFS creates absolute symlinks, which is not great for portability[^1]. This patch addresses that by pushing and popping directories to create relative symlinks.

It also simplifies some instructions:
1. Parsing the soname has been simplified to get rid of an unreadable `sed`. I've elected to use `objdump` over `readelf` because parsing strings between square brackets ain't pretty regardless how it's done.
2. All instances of `test` have been replaced with `[`, which follows the convention in `*LFS-Bootscripts`. It's also more readable imo.
3. Redundant `-f`s have been removed in calls to `ln`. Since we're already checking whether something exists before creating the symlink, it would never be forcibly created.

Note that I've only tested calls to `nvidia_symlink()` on the targets I install. I don't expect my changes to break anything, but you might still want to check that it works for OpenCL, lib32, etc.

[^1]: My DESTDIR install was *mildly* broken. Also in general, making absolute symlinks for files in the same directory is bad practice.