### PR TITLE
Shorten URLs containing /archive/refs/tags to /archive

### DIFF
--- a/wine/misc/libxkbcommon.xml
+++ b/wine/misc/libxkbcommon.xml
@@ -4,7 +4,7 @@
   <!ENTITY % general-entities SYSTEM "../../general.ent">
   %general-entities;
 
-  <!ENTITY libxkbcommon-download-http "https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-&libxkbcommon-version;.tar.gz">
+  <!ENTITY libxkbcommon-download-http "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-&libxkbcommon-version;.tar.gz">
   <!ENTITY libxkbcommon-download-ftp  " ">
 ]>
 


### PR DESCRIPTION
These URLs may be shortened. It's a small style/consistency tweak.