### PR TITLE
libxkbcommon: remove an obsolete sed command.

### DIFF
--- a/wine/misc/libxkbcommon.xml
+++ b/wine/misc/libxkbcommon.xml
@@ -62,13 +62,6 @@
     <title>Installation of libxkbcommon</title>
 
     <para>
-      First, fix an issue when libxml2-2.14 and later is installed by running
-      the following command:
-    </para>
-
-<screen><userinput>sed -i "s/sizeof(dtdstr)/ARRAY_SIZE(dtdstr) - 1/" src/registry.c</userinput></screen>
-
-    <para>
       Install libxkbcommon by running the following
       commands:
     </para>


### PR DESCRIPTION
The problem with libxml2-2.14 was fixed in libxkbcommon-1.9, so this sed should be safe to remove!

Fixes #299