### PR TITLE
glib: 2.84.3 -> 2.84.4 (security)

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,16 @@
     -->
 
     <listitem>
+      <para>August 11th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[renodr] - glib: 2.84.3 -> 2.84.4 (security). Fixes
+          <ulink url="&glfs-issues;/298">#298</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 9th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -34,7 +34,7 @@
 <!ENTITY duktape-version              "2.7.0">
 <!ENTITY pcre2-version                "10.45">
 <!ENTITY glib2-minor                  "2.84">
-<!ENTITY glib2-version                "&glib2-minor;.3">
+<!ENTITY glib2-version                "&glib2-minor;.4">
 <!ENTITY gi-minor                      "1.84">
 <!ENTITY gobject-introspection-version "&gi-minor;.0">
 <!ENTITY icu-major                    "77">


### PR DESCRIPTION
This PR updates glib from 2.84.3 to 2.84.4, fixing CVE-2025-7039. It was tested on a GLFS system that I'm using to fix NVIDIA problems at the moment, and the test suite passed with no failures.

Fixes #298 