### PR TITLE
NSS: Fix download URL

### DIFF
--- a/shareddeps/net/nss.xml
+++ b/shareddeps/net/nss.xml
@@ -5,7 +5,7 @@
   %general-entities;
 
   <!ENTITY nss-url "archive.mozilla.org/pub/security/nss/releases">
-  <!ENTITY nss-download "https://&nss-url;/NSS_&nss-dir;_RTM/src/nss-&nss-version;.tar.gz">
+  <!ENTITY nss-download "https://&nss-url;/NSS_&nss-dir;_RTM/src/nss-&nss-dir;.tar.gz">
 ]>
 
 <sect1 id="nss" xreflabel="nss-&nss-version;">


### PR DESCRIPTION
Mozilla decided to change their tarball naming scheme:

- https://archive.mozilla.org/pub/security/nss/releases/NSS_3_119_RTM/src/
- https://archive.mozilla.org/pub/security/nss/releases/NSS_3_119_1_RTM/src/