### PR TITLE
*: replace `-W no-dev` with `-W no-author`

### DIFF
--- a/core/tooling/llvm.xml
+++ b/core/tooling/llvm.xml
@@ -144,7 +144,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr                     \
       -D LLVM_INCLUDE_BENCHMARKS=OFF                   \
       -D CLANG_DEFAULT_PIE_ON_LINUX=ON                 \
       -D CLANG_CONFIG_FILE_SYSTEM_DIR=/etc/clang       \
-      -W no-dev -G Ninja ../llvm &amp;&amp;
+      -W no-author -G Ninja ../llvm                   &amp;&amp;
 
 ninja</userinput></screen>
 
@@ -195,7 +195,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr                      \
       -D CLANG_BUILD_TOOLS=OFF                          \
       -D CLANG_DEFAULT_PIE_ON_LINUX=ON                  \
       -D CLANG_CONFIG_FILE_SYSTEM_DIR=/etc/clang        \
-      -W no-dev -G Ninja ../llvm &amp;&amp;
+      -W no-author -G Ninja ../llvm                    &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/wine/gs/x265.xml
+++ b/wine/gs/x265.xml
@@ -72,7 +72,7 @@ cd    bld &amp;&amp;
 
 cmake -D CMAKE_INSTALL_PREFIX=/usr        \
       -D GIT_ARCHETYPE=1                  \
-      -W no-dev ../source &amp;&amp;
+      -W no-author ../source             &amp;&amp;
 make</userinput></screen>
 
 
@@ -125,7 +125,7 @@ PKG_CONFIG_PATH=/usr/lib32/pkgconfig      \
 cmake -D CMAKE_INSTALL_PREFIX=/usr        \
       -D LIB_INSTALL_DIR=lib32            \
       -D GIT_ARCHETYPE=1                  \
-      -W no-dev ../source &amp;&amp;
+      -W no-author ../source             &amp;&amp;
 
 make</userinput></screen>
 
@@ -159,8 +159,8 @@ ldconfig</userinput></screen>
     </para>
 
     <para>
-      <parameter>-W no-dev</parameter>: This switch is used to suppress warnings
-      intended for the package developers.
+      <parameter>-W no-author</parameter>: This switch is used to suppress
+      warnings intended for the package developers.
     </para>
 
     <para>

--- a/wine/misc/sdl2.xml
+++ b/wine/misc/sdl2.xml
@@ -57,7 +57,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D SDL2COMPAT_STATIC=OFF       \
       -D SDL2COMPAT_TESTS=OFF        \
-      -W no-dev -G Ninja ..         &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 
@@ -87,7 +87,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D SDL2COMPAT_STATIC=OFF       \
       -D SDL2COMPAT_TESTS=OFF        \
-      -W no-dev -G Ninja ..         &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/wine/misc/sdl3.xml
+++ b/wine/misc/sdl3.xml
@@ -69,7 +69,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D SDL_TEST_LIBRARY=OFF      \
       -D SDL_STATIC=OFF            \
       -D SDL_RPATH=OFF             \
-      -W no-dev -G Ninja ..       &amp;&amp;
+      -W no-author -G Ninja ..    &amp;&amp;
 
 ninja</userinput></screen>
 
@@ -97,7 +97,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D SDL_TEST_LIBRARY=OFF        \
       -D SDL_STATIC=OFF              \
       -D SDL_RPATH=OFF               \
-      -W no-dev -G Ninja ..         &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 


### PR DESCRIPTION
CMake 4.4 emits a deprecation warning for `-W no-dev` suggesting this change.

This was done for BLFS at https://github.com/lfs-book/blfs/commit/eaa0a5cc234def45dc775fa6c3684622305883dd.