### PR TITLE
Package Updates: Fontconfig, libXfont2, mpg123, GStreamer, Wine

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,11 @@
       <para>August 8th, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[Sicarine] - mpg123: 1.33.6 -&gt; 1.33.7 (security). Fixes
+            <ulink url="&glfs-issues;/528">#528</ulink>. See BLFS ticket
+            <ulink url="&blfs-ticket-root;23686">#23686</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[Sicarine] - GStreamer: 1.28.5 -&gt; 1.28.6 (security). Fixes
             <ulink url="&glfs-issues;/526">#526</ulink>. See BLFS ticket
             <ulink url="&blfs-ticket-root;23706">#23706</ulink>.</para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>August 8th, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[Sicarine] - Fontconfig: 2.18.2 -&gt; 2.18.3. Fixes
+            <ulink url="&glfs-issues;/529">#529</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[Sicarine] - libXfont2 (Xorg library): 2.0.8 -&gt; 2.0.9 (security). Fixes
             <ulink url="&glfs-issues;/527">#527</ulink>. See BLFS ticket
             <ulink url="&blfs-ticket-root;23697">#23697</ulink>.</para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,9 @@
       <para>August 8th, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[Sicarine] - Wine: 11.14 -&gt; 11.15.</para>
+        </listitem>
+        <listitem>
           <para>[Sicarine] - Fontconfig: 2.18.2 -&gt; 2.18.3. Fixes
             <ulink url="&glfs-issues;/529">#529</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,11 @@
       <para>August 8th, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[Sicarine] - libXfont2 (Xorg library): 2.0.8 -&gt; 2.0.9 (security). Fixes
+            <ulink url="&glfs-issues;/527">#527</ulink>. See BLFS ticket
+            <ulink url="&blfs-ticket-root;23697">#23697</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[Sicarine] - mpg123: 1.33.6 -&gt; 1.33.7 (security). Fixes
             <ulink url="&glfs-issues;/528">#528</ulink>. See BLFS ticket
             <ulink url="&blfs-ticket-root;23686">#23686</ulink>.</para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,17 @@
     -->
 
     <listitem>
+      <para>August 8th, 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[Sicarine] - GStreamer: 1.28.5 -&gt; 1.28.6 (security). Fixes
+            <ulink url="&glfs-issues;/526">#526</ulink>. See BLFS ticket
+            <ulink url="&blfs-ticket-root;23706">#23706</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 2nd, 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -296,7 +296,7 @@
 <!ENTITY x264-version                 "20250815">
 <!ENTITY x265-version                 "4.2">
 <!ENTITY ffmpeg-version               "8.1.2">
-<!ENTITY gstreamer-version            "1.28.5">
+<!ENTITY gstreamer-version            "1.28.6">
 
 <!ENTITY wine-major-version           "11">
 <!ENTITY wine-version                 "&wine-major-version;.14">

--- a/packages.ent
+++ b/packages.ent
@@ -94,7 +94,7 @@
 <!ENTITY apng-version                 "1.6.58">
 <!ENTITY freetype2-version            "2.14.3">
 <!ENTITY harfbuzz-version             "14.3.0">
-<!ENTITY fontconfig-version           "2.18.2">
+<!ENTITY fontconfig-version           "2.18.3">
 <!-- stable lt .90 micro version -->
 <!-- BEGIN X7LIB -->
 <!ENTITY xtrans-version               "1.6.0">

--- a/packages.ent
+++ b/packages.ent
@@ -299,7 +299,7 @@
 <!ENTITY gstreamer-version            "1.28.6">
 
 <!ENTITY wine-major-version           "11">
-<!ENTITY wine-version                 "&wine-major-version;.14">
+<!ENTITY wine-version                 "&wine-major-version;.15">
 
 <!ENTITY dxvk-version                 "3.0.2">
 <!ENTITY dxvk-libdisplay-info         "275e6459c7ab1ddd4b125f28d0440716e4888078">

--- a/packages.ent
+++ b/packages.ent
@@ -290,7 +290,7 @@
 <!ENTITY dav1d-version                "1.5.4">
 <!ENTITY libaom-version               "3.14.1">
 <!ENTITY fdk-aac-version              "2.0.3">
-<!ENTITY mpg123-version               "1.33.6">
+<!ENTITY mpg123-version               "1.33.7">
 <!ENTITY lame-version                 "4.0">
 <!ENTITY libvpx-version               "1.16.0">
 <!ENTITY x264-version                 "20250815">

--- a/packages.ent
+++ b/packages.ent
@@ -114,7 +114,7 @@
 <!ENTITY libXcursor-version           "1.2.3">
 <!ENTITY libXdamage-version           "1.1.7">
 <!ENTITY libfontenc-version           "1.1.9">
-<!ENTITY libXfont2-version            "2.0.8">
+<!ENTITY libXfont2-version            "2.0.9">
 <!ENTITY libXft-version               "2.3.9">
 <!ENTITY libXi-version                "1.8.3">
 <!ENTITY libXinerama-version          "1.1.6">


### PR DESCRIPTION
Updated a few packages for parity with BLFS. 3 of these are security updates: libXfont2, mpg123, GStreamer.

I'm not overly fond of breaking the 80-character limit on the changelog entries, but I figured it would be a good idea to also link the relevant BLFS ticket for the security-relevant package updates, to be consistent with earlier entries. Let me know if you would like to see any changes.